### PR TITLE
Remove explicitly set CMAKE_BINARY_DIR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-Build/
+build/
 imgui.ini

--- a/Box2D/CMakeLists.txt
+++ b/Box2D/CMakeLists.txt
@@ -6,7 +6,6 @@ cmake_minimum_required(VERSION 2.8)
 
 project(Box2D)
 # Set the output folder where your program will be created
-set(CMAKE_BINARY_DIR ${CMAKE_SOURCE_DIR}/build)
 set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR}/dist/lib)
 
 # The following folder will be included


### PR DESCRIPTION
A cmake project shouldn't set CMAKE_BINARY_DIR itself. It is by default the working directory from which you run cmake, which happens to be the "build" directory used by the build.sh script anyway.

Unless you want to change it.. of course it doesn't hurt. But when using Box2D-MT as a submodule in a larger project you might want to collect all build files in one common location. You also expect CMAKE_BINARY_DIR to be set to the working directory of cmake. Currently it's even impossible to override this.